### PR TITLE
Remove `readme/sort_algorithm.gif` from the published crate & reference the image in the root of the repository instead

### DIFF
--- a/iKeySort/README.md
+++ b/iKeySort/README.md
@@ -11,7 +11,7 @@ parallel execution.
 Optimized for cases where a primary key can be extracted efficiently to index
 elements into buckets.
 
-<img src="readme/sort_algorithm.gif" width="512"/>
+<img src="https://raw.githubusercontent.com/iShape-Rust/iKeySort/main/readme/sort_algorithm.gif" width="512"/>
 
 ## Examples
 


### PR DESCRIPTION
This makes the packaged crate significantly smaller:

| version | # files | uncompressed size | compressed size |
|---------|---------|-------------------|-----------------|
| without | 42      | 5.5MiB            | 5.2MiB          |
| with    | 41      | 104.5KiB          | 16.4KiB         |

Considering all downloads of `i_key_sort`s version 1.10.1 only this
amount to ~300GiB total already.

This change also helps with reviewing dependencies as the
`readme/sort_algorithm.gif` file is a binary file that as such is hard
to impossible to review.
